### PR TITLE
Enum and attribute bugs/features

### DIFF
--- a/src/lib/syntax/ast/declaration.rs
+++ b/src/lib/syntax/ast/declaration.rs
@@ -68,7 +68,7 @@ pub struct StructMember<'ast> {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EnumDeclarator<'ast> {
     pub identifier: IdentifierNode<'ast>,
-    pub type_expression: Option<TypeExpressionNode<'ast>>,
+    pub representation: Option<EnumRepresentationType>,
     pub members: NodeList<'ast, EnumMember<'ast>>,
 }
 

--- a/src/lib/syntax/ast/declaration.rs
+++ b/src/lib/syntax/ast/declaration.rs
@@ -68,6 +68,7 @@ pub struct StructMember<'ast> {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EnumDeclarator<'ast> {
     pub identifier: IdentifierNode<'ast>,
+    pub type_expression: Option<TypeExpressionNode<'ast>>,
     pub values: IdentifierList<'ast>,
 }
 

--- a/src/lib/syntax/ast/declaration.rs
+++ b/src/lib/syntax/ast/declaration.rs
@@ -69,7 +69,13 @@ pub struct StructMember<'ast> {
 pub struct EnumDeclarator<'ast> {
     pub identifier: IdentifierNode<'ast>,
     pub type_expression: Option<TypeExpressionNode<'ast>>,
-    pub values: IdentifierList<'ast>,
+    pub members: NodeList<'ast, EnumMember<'ast>>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct EnumMember<'ast> {
+    pub identifier: IdentifierNode<'ast>,
+    pub value: Option<ExpressionNode<'ast>>,
 }
 
 pub type DeclarationNode<'ast> = Node<'ast, Declaration<'ast>>;

--- a/src/lib/syntax/ast/types.rs
+++ b/src/lib/syntax/ast/types.rs
@@ -40,6 +40,18 @@ pub enum PrimitiveType<'ast> {
     NamedType(IdentifierNode<'ast>),
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum EnumRepresentationType {
+    S8,
+    U8,
+    S16,
+    U16,
+    S32,
+    U32,
+    S64,
+    U64,
+}
+
 pub type TypeExpressionNode<'ast> = Node<'ast, TypeExpression<'ast>>;
 pub type TypeExpressionList<'ast> = NodeList<'ast, TypeExpression<'ast>>;
 

--- a/src/lib/syntax/parser/declaration.rs
+++ b/src/lib/syntax/parser/declaration.rs
@@ -246,8 +246,8 @@ impl<'ast> Parser<'ast> {
     fn enum_declarator(&mut self) -> Result<Declarator<'ast>> {
         self.expect(Token::Enum);
         let identifier = self.identifier_node()?;
-        let type_expression = if self.eat(Token::Colon) {
-            Some(self.type_node()?)
+        let representation = if self.eat(Token::Colon) {
+            Some(self.enum_representation()?)
         } else {
             None
         };
@@ -257,10 +257,38 @@ impl<'ast> Parser<'ast> {
 
         Ok(EnumDeclarator {
             identifier,
-            type_expression,
+            representation,
             members,
         }
         .into())
+    }
+
+    fn enum_representation(&mut self) -> Result<EnumRepresentationType> {
+        match self.current_token {
+            Token::S8 => Ok(EnumRepresentationType::S8),
+            Token::U8 => Ok(EnumRepresentationType::U8),
+            Token::S16 => Ok(EnumRepresentationType::S16),
+            Token::U16 => Ok(EnumRepresentationType::U16),
+            Token::S32 => Ok(EnumRepresentationType::S32),
+            Token::U32 => Ok(EnumRepresentationType::U32),
+            Token::S64 => Ok(EnumRepresentationType::S64),
+            Token::U64 => Ok(EnumRepresentationType::U64),
+            _ => Err(Error::ExpectedOneOfButGot {
+                expected_tokens: vec![
+                    Token::S8,
+                    Token::U8,
+                    Token::S16,
+                    Token::U16,
+                    Token::S32,
+                    Token::U32,
+                    Token::S64,
+                    Token::U64,
+                ],
+                token: self.current_token,
+                raw: self.lexer.slice().into(),
+                span: self.lexer.span(),
+            }),
+        }
     }
 
     fn enum_member_list(&mut self) -> Result<NodeList<'ast, EnumMember<'ast>>> {

--- a/src/lib/syntax/parser/source.rs
+++ b/src/lib/syntax/parser/source.rs
@@ -62,6 +62,7 @@ fn is_declaration_starter(t: Token) -> bool {
         Token::Function => true,
         Token::Struct => true,
         Token::Enum => true,
+        Token::LAttr => true,
         _ => false,
     }
 }


### PR DESCRIPTION
I've fixed a bug related to attributes - the `LAttr` token wasn't recognized as the beginning of a declaration which would cause declarations preceded by an attribute to be missed, and I've brought the enum functionality in-line (I think) with the grammar, adding enum typing ("representation") and member values.

This partially resolves #22 - I'm not sure what would be the best way to proceed, from the state of this branch, to resolve values for unassigned enum members, but I'm presently of the opinion that that doesn't belong in this parser?